### PR TITLE
Allocation Request status shows allocation details when approved. Closes #170.

### DIFF
--- a/rcamp/projects/templates/project-detail.html
+++ b/rcamp/projects/templates/project-detail.html
@@ -103,18 +103,8 @@
   </ul>
   {% endif %}
 
-  <legend>Allocations for {{ object.project_id }}</legend>
-  <ul class="list-group">
-    {% for allocation in allocations %}
-    <h4 class="list-group-item-heading">{{ allocation.allocation_id }}</h4>
-    <p class="list-group-item-text">
-      <strong>Allocated Time:</strong> {{ allocation.amount }} SU
-    </p>
-    {% endfor %}
-  </ul>
-
   {% if user.username in object.managers %}
-  <legend>Allocation Requests for {{ object.project_id }}</legend>
+  <legend>Allocations and Requests for {{ object.project_id }}</legend>
   <ul class="list-group">
     {% for allocation_request in allocation_requests %}
     <a href="{% url 'projects:allocation-request-detail' project_pk=object.pk pk=allocation_request.pk %}" class="list-group-item">
@@ -126,6 +116,14 @@
         {% endif %}
         {% endfor %}
       </p>
+      {% if allocation_request.status == 'a' %}
+      <p class="list-group-item-text">
+        <strong>Allocation ID:</strong> {{ allocation_request.allocation.allocation_id }}
+      </p>
+      <p class="list-group-item-text">
+        <strong>Allocated Time:</strong> {{ allocation_request.allocation.amount }}
+      </p>
+      {% endif %}
     </a>
     {% endfor %}
     <a href="{% url 'projects:allocation-request-create' project_pk=object.pk %}" id="allocation-request-link" class="list-group-item">
@@ -134,6 +132,16 @@
         Request a compute time allocation for this project.
       </p>
     </a>
+  </ul>
+  {% else %}
+  <legend>Allocations for {{ object.project_id }}</legend>
+  <ul class="list-group">
+    {% for allocation in allocations %}
+    <h4 class="list-group-item-heading">{{ allocation.allocation_id }}</h4>
+    <p class="list-group-item-text">
+      <strong>Allocated Time:</strong> {{ allocation.amount }} SU
+    </p>
+    {% endfor %}
   </ul>
   {% endif %}
 </div>


### PR DESCRIPTION
For Project managers, Allocation Request and Allocation details have been collapsed into a single section _(as shown in the screenshot below)_. For collaborators, the Allocation details section is unaffected.

![screen shot 2017-03-01 at 2 06 30 pm](https://cloud.githubusercontent.com/assets/2158268/23481445/929b1cb4-fe88-11e6-8aab-9cfc5fedc697.png)
