### PR TITLE
Issues/196

### DIFF
--- a/rcamp/accounts/models.py
+++ b/rcamp/accounts/models.py
@@ -73,20 +73,9 @@ class AccountRequest(models.Model):
     def __unicode__(self):
         return '%s_%s'%(self.username,self.request_date)
 
-    @classmethod
-    def from_db(cls,db,field_names,values):
-        instance = super(AccountRequest,cls).from_db(db,field_names,values)
-        # Store original field values on the instance
-        instance._loaded_values = dict(zip(field_names,values))
-        return instance
-
     def save(self,*args,**kwargs):
-        # Is model being loaded from db?
-        old_status = 'a'
-        if hasattr(self, '_loaded_values'):
-            old_status = self._loaded_values['status']
-        # Check for change in approval status
-        if (self.status == 'a') and (old_status != 'a'):
+        # Has model already been approved?
+        if (self.status == 'a') and (not self.approved_on):
             # Approval process
             logger.info('Approving account request: '+self.username)
             self.approved_on=timezone.now()

--- a/rcamp/accounts/test_models.py
+++ b/rcamp/accounts/test_models.py
@@ -515,6 +515,7 @@ class AccountRequestTestCase(BaseCase):
             'login_shell': '/bin/bash',
         }
         ar = AccountRequest.objects.create(**self.ar_dict)
+        MockLdapObjectManager.create_user_from_request.reset_mock()
 
     @override_settings(DATABASE_ROUTERS=['lib.router.TestLdapRouter',])
     def test_update_account_request(self):
@@ -525,19 +526,17 @@ class AccountRequestTestCase(BaseCase):
         self.assertEquals(ar.status,'p')
         self.assertIsNone(ar.approved_on)
 
-    @mock.patch('accounts.models.RcLdapUser.objects')
+    @mock.patch('accounts.models.RcLdapUser.objects',MockLdapObjectManager)
     @override_settings(DATABASE_ROUTERS=['lib.router.TestLdapRouter',])
-    def test_update_approved_request(self,mock_ldap_mgr):
-        mock_ldap_mgr = MockLdapObjectManager()
+    def test_update_approved_request(self):
         new_req = copy.deepcopy(self.ar_dict)
         new_req['username'] = 'testuser1'
         new_req['email'] = 'tu1@tu.org'
         new_req['status'] = 'a'
         ar = AccountRequest.objects.create(**new_req)
-        self.assertEqual(mock_ldap_mgr.create_user_from_request.call_count, 1)
         ar.first_name = 'Bob'
         ar.save()
-        self.assertEqual(mock_ldap_mgr.create_user_from_request.call_count, 1)
+        self.assertEqual(MockLdapObjectManager.create_user_from_request.call_count, 1)
 
     @mock.patch('accounts.models.RcLdapUser.objects',MockLdapObjectManager)
     @override_settings(DATABASE_ROUTERS=['lib.router.TestLdapRouter',])

--- a/rcamp/endpoints/tests.py
+++ b/rcamp/endpoints/tests.py
@@ -52,13 +52,13 @@ class AccountRequestEndpointTestCase(TestCase):
         self.ar2.projects.add(self.proj)
 
         del ar_dict['resources_requested']
-        del ar_dict['approved_on']
         ar_dict.update(dict(
             username='testuser3',
             email='tu3@tu.org',
             status='a',
             notes='approved!',
-            id_verified_by='admin'
+            id_verified_by='admin',
+            approved_on=pytz.timezone('America/Denver').localize(datetime.datetime(2016,05,01)),
         ))
         self.ar3 = AccountRequest.objects.create(**ar_dict)
 


### PR DESCRIPTION
Account request approval no longer depends upon values loaded from the DB, so the first save after the approval status is set to _Approved_ will trigger the account creation process.