### PR TITLE
Deprecated old uid attribute for migration. Closes #227.

### DIFF
--- a/rcamp/accounts/models.py
+++ b/rcamp/accounts/models.py
@@ -290,7 +290,7 @@ class RcLdapUser(LdapUser):
 class CuLdapUser(LdapUser):
     base_dn = settings.LDAPCONFS['culdap']['people_dn']
     object_classes = []
-    uid = ldap_fields.IntegerField(db_column='unixUID', unique=True)
+    uid = ldap_fields.IntegerField(db_column='uidNumber', unique=True)
     # Used for automatic determination of role and affiliation.
     edu_affiliation = ldap_fields.ListField(db_column='eduPersonAffiliation')
     edu_primary_affiliation = ldap_fields.CharField(db_column='eduPersonPrimaryAffiliation')


### PR DESCRIPTION
Hotfix for #227. Migrate from `unixUID` to `uidNumber` in the CuLdapUser object.

@anderbubble Tests pass, and I can't see any reason this would destabilize RCAMP. I'm ready to merge and tag a new release if you are.