### PR TITLE
Issues/290

### DIFF
--- a/rcamp/accounts/views.py
+++ b/rcamp/accounts/views.py
@@ -14,7 +14,10 @@ from accounts.forms import (
     AccountRequestVerifyCsuForm,
     AccountRequestIntentForm
 )
-from mailer.signals import account_request_received
+from mailer.signals import (
+    account_request_received,
+    account_request_approved
+)
 
 
 
@@ -115,6 +118,7 @@ class AccountRequestIntentView(FormView):
                 **form.cleaned_data
             )
             intent = Intent.objects.create(**intent_dict)
+            account_request_approved.send(sender=account_request.__class__,account_request=account_request)
         except:
             # TODO: Add proper logging here, but don't make the request fail
             # if creating the Intent object does.

--- a/rcamp/mailer/receivers.py
+++ b/rcamp/mailer/receivers.py
@@ -11,6 +11,15 @@ def notify_account_request_received(sender, **kwargs):
         ctx = {'account_request':account_request}
         msg = notifier.send(context=ctx)
 
+@receiver(account_request_approved)
+def notify_account_request_approved(sender, **kwargs):
+    account_request = kwargs.get('account_request')
+
+    notifiers = MailNotifier.objects.filter(event='account_request_approved')
+    for notifier in notifiers:
+        ctx = {'account_request':account_request}
+        msg = notifier.send(context=ctx)
+
 @receiver(account_created_from_request)
 def notify_account_created_from_request(sender, **kwargs):
     account = kwargs.get('account')

--- a/rcamp/mailer/signals.py
+++ b/rcamp/mailer/signals.py
@@ -2,6 +2,7 @@ import django.dispatch
 
 
 account_request_received = django.dispatch.Signal(providing_args=['account_request'])
+account_request_approved = django.dispatch.Signal(providing_args=['account_request'])
 account_created_from_request = django.dispatch.Signal(providing_args=['account'])
 
 project_created_by_user = django.dispatch.Signal(providing_args=['project'])

--- a/rcamp/mailer/tests.py
+++ b/rcamp/mailer/tests.py
@@ -16,6 +16,7 @@ class EventChoicesTestCase(TestCase):
         from mailer.models import EVENT_CHOICES as event_choices
         expected_choices = (
             ('account_created_from_request', 'account_created_from_request'),
+            ('account_request_approved', 'account_request_approved'),
             ('account_request_received', 'account_request_received'),
             ('allocation_created_from_request', 'allocation_created_from_request'),
             ('allocation_request_created_by_user', 'allocation_request_created_by_user'),


### PR DESCRIPTION
**Changelist**
* Added a new signal, `account_request_approved`, that fires during auto- and manual-approval of an account request. The account request is passed to the receiver function.
* The `account_created_from_request` signal is no longer fired during request approval. This signal will be removed in a future release.