### PR TITLE
Upgrade djangorestframework to 3.9.4

### DIFF
--- a/rcamp/tests/test_endpoints.py
+++ b/rcamp/tests/test_endpoints.py
@@ -92,7 +92,7 @@ class AccountRequestEndpointTestCase(SafeTestCase):
                 u'resources_requested': u'summit',
                 u'organization': u'ucb',
                 u'email': u'tu2@tu.org',
-                u'approved_on': u'2016-04-01T06:00:00Z'
+                u'approved_on': u'2016-04-01T00:00:00Z'
             },
             {
                 u'username': u'testuser3',
@@ -154,7 +154,7 @@ class AccountRequestEndpointTestCase(SafeTestCase):
                 u'resources_requested': u'summit',
                 u'organization': u'ucb',
                 u'email': u'tu2@tu.org',
-                u'approved_on': u'2016-04-01T06:00:00Z'
+                u'approved_on': u'2016-04-01T00:00:00Z'
             }
         ]
         res_content = json.loads(res.content)
@@ -177,7 +177,7 @@ class AccountRequestEndpointTestCase(SafeTestCase):
                 u'resources_requested': u'summit',
                 u'organization': u'ucb',
                 u'email': u'tu2@tu.org',
-                u'approved_on': u'2016-04-01T06:00:00Z'
+                u'approved_on': u'2016-04-01T00:00:00Z'
             }
         ]
         res_content = json.loads(res.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-filter==1.0.2
 django-filters==0.2.1
 django-grappelli==2.10.4
 django-material==0.4.1
-djangorestframework<3.8
+djangorestframework==3.9.4
 funcparserlib==0.3.6
 funcsigs==0.4
 mock==1.3.0


### PR DESCRIPTION
-Fix tests: djangorestframework now respects timezone-aware DateTimeField's
 during serialization. https://www.django-rest-framework.org/community/release-notes/#370