### PR TITLE
Issues/397

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM centos:7
+FROM centos:8
 MAINTAINER Aaron Holt <aaron.holt@colorado.edu>
 
 # Install gosu to drop user and chown shared volumes at runtime
 RUN export GOSU_VERSION=1.10 && \
-    yum -y install epel-release && \
-  	yum -y install wget dpkg && \
+    dnf -y install epel-release && \
+  	dnf -y install wget dpkg && \
   	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" && \
   	wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" && \
   	wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" && \
@@ -14,20 +14,20 @@ RUN export GOSU_VERSION=1.10 && \
   	rm -r "$GNUPGHOME" /tmp/gosu.asc && \
   	chmod +x /usr/bin/gosu; \
   	gosu nobody true && \
-  	yum -y remove wget dpkg && \
-  	yum clean all && \
+  	dnf -y remove wget dpkg && \
+  	dnf clean all && \
     unset GOSU_VERSION
 
 WORKDIR /opt
 
 # Install core dependencies
-RUN yum -y update && \
-    yum makecache fast && \
-    yum -y groupinstall "Development Tools" && \
-    yum -y install epel-release curl which wget && \
-    yum -y install sssd pam-devel openssl-devel pam_radius && \
-    yum -y install python3 python3-devel python3-pip && \
-    yum -y install openldap-devel mysql-devel
+RUN dnf -y update && \
+    dnf -y groupinstall "Development Tools" && \
+    dnf -y install epel-release curl which wget && \
+    dnf -y install sssd pam-devel openssl-devel pam_radius && \
+    dnf -y install python3 python3-devel python3-pip && \
+    dnf -y install openldap-devel mysql-devel sqlite
+RUN dnf clean all
 
 ENV VIRTUAL_ENV=/opt/rcamp_venv
 RUN python3 -m venv $VIRTUAL_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ ADD requirements.txt /opt/
 RUN pip3 install --upgrade pip && \
     pip3 install -r requirements.txt
 
-RUN pwd
 RUN git clone -b python3 https://github.com/ResearchComputing/django-ldapdb-test-env
 WORKDIR django-ldapdb-test-env
 RUN python3 setup.py install

--- a/rcamp/lib/views.py
+++ b/rcamp/lib/views.py
@@ -4,7 +4,7 @@ from django.template import RequestContext
 from django.shortcuts import redirect
 
 
-def handler404(request):
+def handler404(request, exception=None):
     return render(request, '404.html', {}, status=404)
 
 

--- a/rcamp/lib/views.py
+++ b/rcamp/lib/views.py
@@ -12,7 +12,7 @@ def handler500(request):
     return render(request, '500.html', {}, status=500)
 
 def index_view(request):
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect('projects:project-list')
 
     return render(request, 'index.html', {})

--- a/rcamp/rcamp/settings/main.py
+++ b/rcamp/rcamp/settings/main.py
@@ -34,16 +34,15 @@ INSTALLED_APPS = [
 if DEBUG:
     INSTALLED_APPS.append('tests')
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-)
+]
 
 ROOT_URLCONF = 'rcamp.urls'
 

--- a/rcamp/rcamp/urls.py
+++ b/rcamp/rcamp/urls.py
@@ -33,8 +33,8 @@ handler500 = 'lib.views.handler500'
 urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')), # grappelli URLS
     url(r'^$', index_view, name='index'),
-    url(r'^login', auth_views.login, {'template_name':'login.html'}),
-    url(r'^logout', auth_views.logout, {'template_name':'logout.html'}),
+    url(r'^login', auth_views.LoginView, {'template_name':'login.html'}),
+    url(r'^logout', auth_views.LogoutView, {'template_name':'logout.html'}),
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include('endpoints.urls')),
     url(r'^accounts/', include(('accounts.urls', 'accounts'), namespace='accounts')),

--- a/rcamp/tests/utilities/utils.py
+++ b/rcamp/tests/utilities/utils.py
@@ -77,6 +77,8 @@ class SafeTestCase(TestCase):
     IMPORTANT: Every unit or integration test should inherit from this class. For functional tests
     user tests.utilities.functional.SafeStaticLiveServerTestCase instead.
     """
+    databases = frozenset({'default', 'culdap', 'csuldap', 'rcldap'})
+
     @classmethod
     def setUpClass(cls):
         assert_test_env()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>2,<2.2
+Django>=2.2,<3
 django-crispy-forms==1.8.1
 django-easy-pjax==1.2.0
 django-filter==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-Django>2,<2.1
+Django>2,<2.2
 django-crispy-forms==1.8.1
 django-easy-pjax==1.2.0
-django-filter==2.1.0
+django-filter==2.2.0
 django-grappelli==2.10.4
 django-material==0.4.1
-djangorestframework==3.9.4
+djangorestframework==3.10.3
 funcparserlib==0.3.6
 funcsigs==0.4
 mock==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.29
+Django>2,<2.1
 django-crispy-forms==1.8.1
 django-easy-pjax==1.2.0
 django-filter==2.1.0


### PR DESCRIPTION
Upgrade to Django 2.2
Upgrade djangorestframework to 3.10, django-filter to 2.2
Upgrade Docker container to Centos 8 for sqlite 3.8+
Specify database query access in unit tests

Required fixes from Django 1.11 to 2.2:
- MIDDLEWARE_CLASSES now MIDDLEWARE
- auth_views.login/logout now auth_views.LoginView/LogoutView
- is_authenticated is now a property